### PR TITLE
fix: normalize repository.url

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "homepage": "https://github.com/zekariasasaminew/instruct-sync#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/zekariasasaminew/instruct-sync.git"
+    "url": "git+https://github.com/zekariasasaminew/instruct-sync.git"
   },
   "bugs": {
     "url": "https://github.com/zekariasasaminew/instruct-sync/issues"


### PR DESCRIPTION
Fixes npm publish warning about repository.url format.