### PR TITLE
fix: 5 bugs found during testing

### DIFF
--- a/src/commands/add.ts
+++ b/src/commands/add.ts
@@ -25,7 +25,8 @@ export async function add(nameOrSource: string, flags: { tool?: string; target?:
     tools = (Object.keys(pack.targets) as ToolName[]).filter((t) => detected.includes(t));
     if (tools.length === 0) tools = ["copilot"]; // fallback
   } else {
-    tools = ["copilot"]; // v1 pack: copilot only
+    // v1/cross-tool pack: use pack.tool if specified, otherwise copilot
+    tools = [((pack.tool as ToolName) ?? "copilot")];
   }
 
   const installed: string[] = [];
@@ -62,13 +63,22 @@ export async function add(nameOrSource: string, flags: { tool?: string; target?:
   for (const line of installed) console.log(line);
   if (skipped.length > 0) console.log(`  Skipped (already installed): ${skipped.join(", ")}`);
 
-  if (installed.length > 0 && !flags.tool && !pack.targets) {
+  // Hint: show available tool variants that weren't installed
+  if (installed.length > 0 && !flags.tool && pack.targets) {
+    const notInstalled = (Object.keys(pack.targets) as ToolName[]).filter((t) => !tools.includes(t));
+    if (notInstalled.length > 0) {
+      console.log(`  Hint: ${notInstalled.join(", ")} variants also available. Run: instruct-sync add ${nameOrSource} --tool <tool>`);
+    }
+  } else if (installed.length > 0 && !flags.tool && !pack.targets && pack.tool !== "agents") {
     console.log(`  Hint: Run with --tool cursor|claude|windsurf to install for other tools`);
   }
 }
 
 async function addDirect(source: string, flags: { tool?: string; target?: string }): Promise<void> {
-  const name = source.split("/").pop()!.replace(/\.md$/, "").replace(/^github:/, "");
+  const name = source.split("/").pop()!
+    .replace(/@[^@]*$/, "")  // strip @ref (e.g. @HEAD, @v1.0.0)
+    .replace(/\.md$/, "")
+    .replace(/^github:/, "");
   const tool = (flags.tool as ToolName) ?? "copilot";
   const lockKey = `${name}@${tool}`;
 

--- a/src/commands/browse.ts
+++ b/src/commands/browse.ts
@@ -13,6 +13,7 @@ export async function browse(): Promise<void> {
     return;
   }
 
+  let variantCount = 0;
   console.log(`${"Pack".padEnd(20)} ${"Tool".padEnd(12)} ${"Description"}`);
   console.log(`${"─".repeat(20)} ${"─".repeat(12)} ${"─".repeat(40)}`);
   for (const pack of packs) {
@@ -20,11 +21,15 @@ export async function browse(): Promise<void> {
       // v2: one row per tool
       for (const tool of Object.keys(pack.targets)) {
         console.log(`${pack.name.padEnd(20)} ${tool.padEnd(12)} ${pack.description}`);
+        variantCount++;
       }
     } else {
       const tool = pack.tool ?? "copilot";
       console.log(`${pack.name.padEnd(20)} ${String(tool).padEnd(12)} ${pack.description}`);
+      variantCount++;
     }
   }
-  console.log(`\n${packs.length} pack(s) available. Run: instruct-sync add <name>`);
+  const packWord = packs.length === 1 ? "pack" : "packs";
+  const variantNote = variantCount > packs.length ? ` (${variantCount} variants)` : "";
+  console.log(`\n${packs.length} ${packWord} available${variantNote}. Run: instruct-sync add <name>`);
 }

--- a/src/commands/remove.ts
+++ b/src/commands/remove.ts
@@ -17,6 +17,7 @@ export function remove(name: string, flags: { tool?: string } = {}): void {
 
   if (keysToRemove.length === 0) {
     console.log(`"${name}" is not installed. Run: instruct-sync installed`);
+    process.exitCode = 1;
     return;
   }
 

--- a/src/registry.ts
+++ b/src/registry.ts
@@ -23,7 +23,7 @@ export async function findPack(name: string): Promise<RegistryEntry> {
  */
 export function getToolTarget(pack: RegistryEntry, tool: ToolName): ToolTarget | undefined {
   if (pack.targets?.[tool]) return pack.targets[tool];
-  // v1 fallback: single source, derive default target path
-  if (pack.source) return { source: pack.source, target: "" }; // empty = use defaultTarget()
+  // v1/cross-tool pack: use pack-level source + target
+  if (pack.source) return { source: pack.source, target: pack.target ?? "" };
   return undefined;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,8 @@ export interface RegistryEntry {
   description: string;
   /** v1 only — single source for all tools */
   source?: string;
+  /** v1 only — explicit target path (e.g. AGENTS.md) */
+  target?: string;
   /** v2 only — per-tool source+target */
   targets?: Partial<Record<ToolName, ToolTarget>>;
   /** if present, this pack is for one specific tool only */

--- a/tests/browse.test.ts
+++ b/tests/browse.test.ts
@@ -15,7 +15,7 @@ describe("browse", () => {
     const output = spy.mock.calls.map((c) => c[0]).join("\n");
     expect(output).toContain("react");
     expect(output).toContain("typescript");
-    expect(output).toContain("2 pack(s) available");
+    expect(output).toContain("2 packs available");
     spy.mockRestore();
   });
 


### PR DESCRIPTION
Found by running a full first-time-user test suite against v0.2.0.

## Bugs fixed

1. **\gents\ pack installs to wrong path** — \getToolTarget()\ ignored \pack.target\ field, fell back to \defaultTarget()\. Now: \getToolTarget\ returns \pack.target\ if set. \RegistryEntry\ now has \	arget?\ field.

2. **\github:\ direct source name parsing keeps \@ref\** — \github:org/repo/react.md@HEAD\ produced name \eact.md@HEAD\ → target \.github/instructions/react.md@HEAD.instructions.md\. Fix: strip \@ref\ suffix from name.

3. **No hint shown after \dd react\ (v2 packs)** — condition was \!pack.targets\ so v2 packs never showed hint. Fixed: now shows which tool variants are available but weren't detected.

4. **\gents\ pack tool key wrong** — v1 packs with \	ool: 'agents'\ were stored as \gents@copilot\. Fixed: use \pack.tool\ as the tool key when it's set.

5. **\emove nonexistent\ exits 0** — should exit 1. Fixed with \process.exitCode = 1\ (doesn't break tests like \process.exit(1)\ would).

6. **\list\ count misleading** — said '6 pack(s) available' but showed 21 rows. Fixed to show '6 packs available (21 variants)'